### PR TITLE
Add new common package with OpenForTesting annotation

### DIFF
--- a/common/common.gradle.kts
+++ b/common/common.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    `java-library`
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
+configure<PublishingExtension> {
+    publications {
+        register<MavenPublication>("gpr") {
+            from(components["java"])
+        }
+    }
+}

--- a/common/src/main/java/info/offthecob/common/OpenForTesting.java
+++ b/common/src/main/java/info/offthecob/common/OpenForTesting.java
@@ -1,0 +1,4 @@
+package info.offthecob.common;
+
+public @interface OpenForTesting {
+}


### PR DESCRIPTION
This new annotation will be used downstream to open classes for mocking
with unit tests.