### PR TITLE
Add gradle best practices plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,42 @@ JVM Platform
 ============
 This is a set of "jvm platforms" intended to help me keep my personal projects
 libraries up to date.
+
+# Catalog
+Produces an artifact containing the library versions maintained in `libs.versions.toml`.
+This artifact can be used downstream in other projects with the gradle `versionsCatalog`
+api. Essentially the catalog helps keep the list of approved libraries maintained in 
+one place.
+
+# Plugins
+A list of best practices around dependency locking, linting, and other build best practices.
+This subproject also allows me to do all the things I do in every project in one place, cleaning up
+the downstream consumer's gradle files.
+
+## Base
+This plugin contains what I think are best practices for all jvm projects.
+
+```gradle
+plugins {
+    id("info.offthecob.Base")
+}
+```
+
+## Library
+This includes everything in base, but enables the `java-library` plugin, adding the api configuration
+as well as the jar task
+
+```gradle
+plugins {
+    id("info.offthecob.Library")
+}
+```
+
+## Service
+Similar to library, where it is based on the base plugin, but this plugin adds jib (a java native container builder).
+
+```gradle
+plugins {
+    id("info.offthecob.Service")
+}
+```

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -8,41 +8,50 @@ gson = "2.9.0"
 guava = "30.1.1-jre"
 guice = "5.1.0"
 jacoco = "0.8.7"
-jib = "3.2.1"
-junit = "5.6.0"
+jib = "3.3.2"
+junit = "5.9.1"
 klaxon = "5.5"
 kotlin = "1.6.21"
 kotlin-guice = "1.6.0"
 kotlin-logging = "1.7.6"
 logback = "1.2.3"
+nullaway-plugin = "1.5.0"
 objenesis = "3.2"
 slf4j = "1.7.25"
 spock = "2.2-M1-groovy-3.0"
+spotless = "6.20.0"
 
 [libraries]
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang" }
-commons-lang = { module = "commons-lang:commons-lang", version.ref = "commons-lang"}
+commons-lang = { module = "commons-lang:commons-lang", version.ref = "commons-lang" }
+errorprone-core = { module = "com.google.errorprone:error_prone_core", version = "2.18.0" }
+errorprone-plugin = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version = "3.1.0" }
 google-guice = { module = "com.google.inject:guice", version.ref = "guice" }
 graphql = { module = "com.graphql-java:graphql-java", version.ref = "graphql" }
-groovy-lang = { module = "org.codehaus.groovy:groovy", version.ref = "groovy"}
-groovy-json = { module = "org.codehaus.groovy:groovy-json", version.ref = "groovy"}
+groovy-lang = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }
+groovy-json = { module = "org.codehaus.groovy:groovy-json", version.ref = "groovy" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.0.1" }
+jib = { module = "com.google.cloud.tools:jib-gradle-plugin", version.ref = "jib" }
 junit = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "1.9.3" }
 klaxon = { module = "com.beust:klaxon", version.ref = "klaxon" }
 kotlin-logging = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlin-logging" }
-kotlin-guice = { module = "dev.misfitlabs.kotlinguice4:kotlin-guice",  version.ref = "kotlin-guice" }
+kotlin-guice = { module = "dev.misfitlabs.kotlinguice4:kotlin-guice", version.ref = "kotlin-guice" }
 lambda-core = { module = "com.amazonaws:aws-lambda-java-core", version = { strictly = "1.2.1" } }
 lambda-events = { module = "com.amazonaws:aws-lambda-java-events", version = { strictly = "3.9.0" } }
 lambda-runtime = { module = "com.amazonaws:aws-lambda-java-runtime-interface-client", version = { strictly = "2.1.1" } }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 logback-core = { module = "ch.qos.logback:logback-core", version.ref = "logback" }
+nullaway-plugin = { module = "net.ltgt.gradle:gradle-nullaway-plugin", version.ref = "nullaway-plugin" }
 objenesis = { module = "org.objenesis:objenesis", version.ref = "objenesis" }
 slf4j-jul = { module = "org.slf4j:jul-to-slf4j", version.ref = "slf4j" }
 slf4j-jcl = { module = "org.slf4j:jcl-over-slf4j", version.ref = "slf4j" }
 slf4j-log4j = { module = "org.slf4j:jcl-over-slf4j", version.ref = "slf4j" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
+spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 
 [bundles]
 apache-commons = ["commons-lang3", "commons-lang"]
@@ -57,3 +66,5 @@ dependencycheck = { id = "org.owasp.dependencycheck", version.ref = "dependencyc
 jib = { id = "com.google.cloud.tools.jib", version.ref = "jib" }
 kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+nullaway = { id = "net.ltgt.nullaway", version.ref = "nullaway-plugin" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -1,0 +1,67 @@
+plugins {
+    `java-gradle-plugin`
+    java
+    groovy
+    `kotlin-dsl`
+    alias(libs.plugins.spotless)
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+java {
+    withSourcesJar()
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+        vendor.set(JvmVendorSpec.ADOPTIUM)
+    }
+}
+
+gradlePlugin {
+    plugins {
+        create("base") {
+            id = "info.offthecob.Base"
+            implementationClass = "info.offthecob.gradle.BasePlugin"
+        }
+        create("service") {
+            id = "info.offthecob.Service"
+            implementationClass = "info.offthecob.gradle.ServicePlugin"
+        }
+        create("library") {
+            id = "info.offthecob.Library"
+            implementationClass = "info.offthecob.gradle.LibraryPlugin"
+        }
+    }
+}
+
+dependencies {
+    implementation(gradleApi())
+    api(libs.jib)
+    api(libs.nullaway.plugin)
+    api(libs.spotless)
+    compileOnly(libs.jetbrains.annotations)
+
+    testImplementation(gradleTestKit())
+    testImplementation(libs.spock.core)
+    testImplementation(libs.junit)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+tasks {
+    named("testClasses") {
+        dependsOn("pluginUnderTestMetadata")
+    }
+
+    withType<Test>().configureEach {
+        useJUnitPlatform()
+    }
+}
+
+spotless {
+    kotlin {
+        ktlint()
+        target("src/**/*.kt")
+    }
+}

--- a/plugins/src/main/kotlin/info/offthecob/gradle/BasePlugin.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/BasePlugin.kt
@@ -1,0 +1,31 @@
+package info.offthecob.gradle
+
+import com.diffplug.gradle.spotless.SpotlessPlugin
+import net.ltgt.gradle.nullaway.NullAwayPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.api.plugins.GroovyPlugin
+import org.gradle.api.plugins.JavaPlugin
+
+const val PROJECT_BUILDER_TEST = "project-builder-test"
+
+class BasePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.plugins.apply {
+            apply(JavaPlugin::class.java)
+            apply(JavaCustomization::class.java)
+            apply(GroovyPlugin::class.java)
+            apply(NullAwayPlugin::class.java)
+            apply(NullAwayCustomization::class.java)
+            apply(DependencyLocking::class.java)
+            val ext = project.extensions.getByType(ExtraPropertiesExtension::class.java)
+
+            // Spotless is not currently compatible with the ProjectBuilder test framework
+            if (!ext.properties.containsKey(PROJECT_BUILDER_TEST)) {
+                apply(SpotlessPlugin::class.java)
+                apply(SpotlessCustomization::class.java)
+            }
+        }
+    }
+}

--- a/plugins/src/main/kotlin/info/offthecob/gradle/DependencyLocking.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/DependencyLocking.kt
@@ -1,0 +1,48 @@
+package info.offthecob.gradle
+
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ResolutionStrategy
+import org.gradle.api.artifacts.dsl.LockMode
+
+const val RUNTIME_CLASSPATH = "runtimeClasspath"
+const val COMPILE_CLASSPATH = "compileClasspath"
+const val ANNOTATION_PROCESSOR = "annotationProcessor"
+val LOCKED_CONFIGURATIONS = listOf(RUNTIME_CLASSPATH, COMPILE_CLASSPATH, ANNOTATION_PROCESSOR)
+
+const val RESOLVE_AND_LOCK_ALL = "resolveAndLockAll"
+
+class DependencyLocking : Plugin<Project> {
+    override fun apply(project: Project) {
+        enableLocking(project)
+        lockAndResolveAll(project)
+    }
+
+    private fun lockAndResolveAll(project: Project) {
+        project.tasks.register(RESOLVE_AND_LOCK_ALL) {
+            doFirst {
+                if (!project.gradle.startParameter.isWriteDependencyLocks) {
+                    throw GradleException("--write-locks is not set")
+                }
+            }
+            doLast {
+                LOCKED_CONFIGURATIONS.forEach {
+                    val configuration = project.configurations.getByName(it)
+                    if (configuration.isCanBeResolved) {
+                        configuration.resolve()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun enableLocking(project: Project) {
+        project.dependencyLocking.lockMode.set(LockMode.STRICT)
+        project.configurations.apply {
+            LOCKED_CONFIGURATIONS.forEach {
+                getByName(it).resolutionStrategy(ResolutionStrategy::activateDependencyLocking)
+            }
+        }
+    }
+}

--- a/plugins/src/main/kotlin/info/offthecob/gradle/JavaCustomization.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/JavaCustomization.kt
@@ -1,0 +1,26 @@
+package info.offthecob.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmVendorSpec
+
+val JVM_VERSION = JavaLanguageVersion.of(17)
+val JVM_VENDOR = JvmVendorSpec.ADOPTIUM
+
+class JavaCustomization : Plugin<Project> {
+    override fun apply(project: Project) {
+        val java = project.extensions.findByType(JavaPluginExtension::class.java)
+        setupToolchain(java!!)
+        project.tasks.withType(Test::class.java, Test::useJUnitPlatform)
+    }
+
+    private fun setupToolchain(java: JavaPluginExtension) {
+        java.toolchain.apply {
+            languageVersion.set(JVM_VERSION)
+            vendor.set(JVM_VENDOR)
+        }
+    }
+}

--- a/plugins/src/main/kotlin/info/offthecob/gradle/LibraryPlugin.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/LibraryPlugin.kt
@@ -1,0 +1,14 @@
+package info.offthecob.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaLibraryPlugin
+
+class LibraryPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.plugins.apply {
+            apply(BasePlugin::class.java)
+            apply(JavaLibraryPlugin::class.java)
+        }
+    }
+}

--- a/plugins/src/main/kotlin/info/offthecob/gradle/NullAwayCustomization.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/NullAwayCustomization.kt
@@ -1,0 +1,15 @@
+package info.offthecob.gradle
+
+import net.ltgt.gradle.nullaway.NullAwayExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+const val NULL_AWAY_ANNOTATED_PACKAGES = "net.ltgt"
+
+class NullAwayCustomization : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.extensions.getByType(NullAwayExtension::class.java).apply {
+            annotatedPackages.add(NULL_AWAY_ANNOTATED_PACKAGES)
+        }
+    }
+}

--- a/plugins/src/main/kotlin/info/offthecob/gradle/ServicePlugin.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/ServicePlugin.kt
@@ -1,0 +1,14 @@
+package info.offthecob.gradle
+
+import com.google.cloud.tools.jib.gradle.JibPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class ServicePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.plugins.apply {
+            apply(BasePlugin::class.java)
+            apply(JibPlugin::class.java)
+        }
+    }
+}

--- a/plugins/src/main/kotlin/info/offthecob/gradle/SpotlessCustomization.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/SpotlessCustomization.kt
@@ -1,0 +1,22 @@
+package info.offthecob.gradle
+
+import com.diffplug.gradle.spotless.SpotlessExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class SpotlessCustomization : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.extensions.getByType(SpotlessExtension::class.java).apply {
+            java {
+                importOrder()
+                removeUnusedImports()
+                googleJavaFormat()
+                target("src/**/*.java")
+            }
+            kotlin {
+                ktlint()
+                target("src/**/*.kt")
+            }
+        }
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/BasePluginTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/BasePluginTest.groovy
@@ -1,0 +1,28 @@
+package info.offthecob.gradle
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+
+class BasePluginTest extends IntegrationSpec {
+    def "happy path"() {
+        given:
+        def gradleArguments = [
+                "clean",
+                "spotlessApply",
+                "check",
+                "-Pproject_directory=${projectDirectory}" as String,
+                "--write-locks"
+        ] as List<String>
+
+        when:
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(projectDirectory)
+                .withArguments(gradleArguments)
+                .build()
+
+        then:
+        result.task(":check").getOutcome() == TaskOutcome.SUCCESS
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/DependencyLockingIntegrationTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/DependencyLockingIntegrationTest.groovy
@@ -1,0 +1,27 @@
+package info.offthecob.gradle
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+
+class DependencyLockingIntegrationTest extends IntegrationSpec {
+    def "verify locking is enabled"() {
+        given:
+        def gradleArguments = [
+                "clean",
+                "spotlessApply",
+                "check",
+                "-Pproject_directory=${projectDirectory}" as String
+        ] as List<String>
+
+        when:
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(projectDirectory)
+                .withArguments(gradleArguments)
+                .buildAndFail()
+
+        then:
+        result.task(":compileKotlin").getOutcome() == TaskOutcome.FAILED
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/DependencyLockingTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/DependencyLockingTest.groovy
@@ -1,0 +1,24 @@
+package info.offthecob.gradle
+
+import spock.lang.Shared
+import spock.lang.TempDir
+
+import static info.offthecob.gradle.DependencyLockingKt.RESOLVE_AND_LOCK_ALL
+
+class DependencyLockingTest extends UnitSpec {
+    @Shared
+    @TempDir
+    File projectDir
+
+    def setupSpec() {
+        setupProject("info.offthecob.Base")
+    }
+
+    def "locking helper task exists"() {
+        given:
+        def resolveAndLockAll = project.getTasksByName(RESOLVE_AND_LOCK_ALL, true)
+
+        expect:
+        !resolveAndLockAll.isEmpty()
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/IntegrationSpec.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/IntegrationSpec.groovy
@@ -1,0 +1,15 @@
+package info.offthecob.gradle
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class IntegrationSpec extends Specification {
+    @Shared
+    @TempDir
+    File projectDirectory
+
+    def setupSpec() {
+        new IntegrationTestUtils(projectDirectory).setupDefaultProject()
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/IntegrationTestUtils.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/IntegrationTestUtils.groovy
@@ -1,0 +1,126 @@
+package info.offthecob.gradle
+
+import org.intellij.lang.annotations.Language
+
+class IntegrationTestUtils {
+    private final File projectDir
+
+    IntegrationTestUtils(File projectDir) {
+        this.projectDir = projectDir
+    }
+
+    void setupDefaultProject() {
+        defaultSettings()
+        defaultBuildGradle()
+        defaultJavaMain()
+        defaultKotlin()
+        defaultTesting()
+    }
+
+    void defaultSettings() {
+        def settings = new File(projectDir, "settings.gradle.kts")
+        def libraryDir = new File(System.getProperty("user.dir")).parentFile
+        settings << """
+        plugins {
+            id("org.gradle.toolchains.foojay-resolver") version "0.6.0"
+        }
+        rootProject.name = "test-project"
+        toolchainManagement {
+            jvm {
+                javaRepositories {
+                    repository("foojay") {
+                        resolverClass.set(org.gradle.toolchains.foojay.FoojayToolchainResolver::class.java)
+                    }
+                }
+            }
+        }
+        dependencyResolutionManagement {
+            repositories {
+                mavenCentral()
+                gradlePluginPortal()
+            }
+            versionCatalogs {
+                create("libs") {
+                    from(files("${libraryDir.absolutePath}/libs.versions.toml"))
+                }
+            }
+        }
+        """.stripIndent()
+    }
+
+    void defaultBuildGradle() {
+        def buildGradle = new File(projectDir, "build.gradle.kts")
+        buildGradle << """
+        plugins {
+            id("info.offthecob.Base")
+            kotlin("jvm") version "1.9.0"
+        }
+        dependencies {
+            implementation(libs.google.guice)
+            testImplementation(libs.spock.core)
+            testImplementation(libs.junit)
+            testRuntimeOnly(libs.junit.platform.launcher)
+        }
+        """.stripIndent()
+    }
+
+    void defaultJavaMain() {
+        def srcMain = new File(projectDir, "src/main/java/info/offthecob/testing")
+        srcMain.mkdirs()
+        def mainFile = new File(srcMain, "Main.java")
+        @Language("java")
+        def main = """
+        package info.offthecob.testing;
+        public class Main {
+            public static final String FORMATTED_STRING = "%s+1";
+            
+            public static void main(String[] args){
+                System.out.println("boom");
+            }
+            
+            public String method(String input) {
+                return FORMATTED_STRING.formatted(input);
+            }
+        }
+        """.stripIndent()
+        mainFile << main
+    }
+
+    void defaultTesting() {
+        def srcTest = new File(projectDir, "src/test/groovy/info/offthecob/testing")
+        srcTest.mkdirs()
+        def mainTestFile = new File(srcTest, "MainTest.groovy")
+        @Language("groovy")
+        def mainTest = """
+        package info.offthecob.testing
+        import spock.lang.Specification
+        class MainTest extends Specification {
+            def "main outputs expected value"() {
+                given:
+                def input = "test input"
+                
+                when:
+                def observed = new Main().method(input)
+                
+                then:
+                observed == Main.FORMATTED_STRING.formatted(input)
+            }
+        }
+        """.stripIndent()
+        mainTestFile << mainTest
+    }
+
+    void defaultKotlin() {
+        def srcMain = new File(projectDir, "src/main/kotlin/info/offthecob/testing")
+        srcMain.mkdirs()
+        def kotlinFile = new File(srcMain, "KotlinFunctional.kt")
+
+        // new line below is intentional because it causes the spotless linter to fail
+        def function = """
+        package info.offthecob.testing
+        fun functionalFun(input: String, input2: String,
+                          input3: String): String { return "${'$'}input functional" }
+        """.stripIndent()
+        kotlinFile << function
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/JavaCustomizationTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/JavaCustomizationTest.groovy
@@ -1,0 +1,34 @@
+package info.offthecob.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test
+
+class JavaCustomizationTest extends UnitSpec {
+
+    def setupSpec() {
+        setupProject("info.offthecob.Base")
+    }
+
+    def "toolchain configuration"() {
+        when:
+        def toolchain = project.getExtensions().getByType(JavaPluginExtension.class).getToolchain()
+
+        then:
+        toolchain.languageVersion.get() == JavaCustomizationKt.JVM_VERSION
+        toolchain.vendor.get() == JavaCustomizationKt.JVM_VENDOR
+    }
+
+    def "test use junit platform"() {
+        given:
+        def tests = project.tasks.withType(Test.class)
+
+        expect:
+        tests.each {
+            if(!(it.testFramework instanceof JUnitPlatformTestFramework)) {
+                assert false
+            }
+        }
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/LibraryPluginTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/LibraryPluginTest.groovy
@@ -1,0 +1,17 @@
+package info.offthecob.gradle
+
+import spock.lang.Specification
+
+class LibraryPluginTest extends UnitSpec {
+    def setupSpec() {
+        setupProject("info.offthecob.Library")
+    }
+
+    def "contains jib task"() {
+        given:
+        def jar = project.getTasksByName("jar", true)
+
+        expect:
+        !jar.isEmpty()
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/NullAwayCustomizationTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/NullAwayCustomizationTest.groovy
@@ -1,0 +1,17 @@
+package info.offthecob.gradle
+
+import net.ltgt.gradle.nullaway.NullAwayExtension
+
+class NullAwayCustomizationTest extends UnitSpec {
+    def setupSpec() {
+        setupProject("info.offthecob.Base")
+    }
+
+    def "annotations set"() {
+        when:
+        def nullAway = project.extensions.getByType(NullAwayExtension.class)
+
+        then:
+        nullAway.annotatedPackages.get().first() == NullAwayCustomizationKt.NULL_AWAY_ANNOTATED_PACKAGES
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/ServicePluginTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/ServicePluginTest.groovy
@@ -1,0 +1,16 @@
+package info.offthecob.gradle
+
+
+class ServicePluginTest extends UnitSpec {
+    def setupSpec() {
+        setupProject("info.offthecob.Service")
+    }
+
+    def "contains jib task"() {
+        given:
+        def jib = project.getTasksByName("jib", true)
+
+        expect:
+        !jib.isEmpty()
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/SpotlessCustomizationTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/SpotlessCustomizationTest.groovy
@@ -1,0 +1,77 @@
+package info.offthecob.gradle
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Unroll
+
+
+class SpotlessCustomizationTest extends IntegrationSpec {
+
+    @Unroll
+    def "#checkTask finds styles that need to be applied"() {
+        given:
+        def gradleArguments = [
+                checkTask,
+                "-Pproject_directory=${projectDirectory}" as String,
+                "--write-locks"
+        ] as List<String>
+
+        when:
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(projectDirectory)
+                .withArguments(gradleArguments)
+                .buildAndFail()
+
+        then:
+        result.task(":${checkTask}").getOutcome() == TaskOutcome.FAILED
+
+        where:
+        checkTask             | _
+        "spotlessJavaCheck"   | _
+        "spotlessKotlinCheck" | _
+    }
+
+
+    @Unroll
+    def "#spotlessApply fixes #spotlessCheck"() {
+        given:
+        def gradleArguments = [
+                spotlessApply,
+                "-Pproject_directory=${projectDirectory}" as String,
+                "--write-locks"
+        ] as List<String>
+
+        when:
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(projectDirectory)
+                .withArguments(gradleArguments)
+                .build()
+
+        then:
+        result.task(":${spotlessApply}").getOutcome() == TaskOutcome.SUCCESS
+
+        and:
+        def checkGradleArguments = [
+                "clean",
+                spotlessCheck,
+                "-Pproject_directory=${projectDirectory}" as String,
+                "--write-locks"
+        ] as List<String>
+        def checkResult = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(projectDirectory)
+                .withArguments(checkGradleArguments)
+                .build()
+
+        then:
+        checkResult.task(":${spotlessCheck}").getOutcome() == TaskOutcome.SUCCESS
+
+        where:
+        spotlessApply         | spotlessCheck
+        "spotlessKotlinApply" | "spotlessKotlinCheck"
+        "spotlessJavaApply"   | "spotlessJavaCheck"
+    }
+}

--- a/plugins/src/test/groovy/info/offthecob/gradle/UnitSpec.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/UnitSpec.groovy
@@ -1,0 +1,21 @@
+package info.offthecob.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static info.offthecob.gradle.BasePluginKt.PROJECT_BUILDER_TEST
+
+class UnitSpec extends Specification {
+    @Shared
+    Project project
+
+    def setupProject(String pluginName) {
+        project = ProjectBuilder.builder().build()
+        def ext = project.extensions.getByType(ExtraPropertiesExtension.class)
+        ext.set(PROJECT_BUILDER_TEST, "true")
+        project.getPluginManager().apply(pluginName)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,17 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver") version "0.6.0"
+}
+
+toolchainManagement {
+    jvm {
+        javaRepositories {
+            repository("foojay") {
+                resolverClass.set(org.gradle.toolchains.foojay.FoojayToolchainResolver::class.java)
+            }
+        }
+    }
+}
+
 rootProject.name = "jvm-platform"
 
 dependencyResolutionManagement {


### PR DESCRIPTION
These plugins are based off of years of working on gradle projects. The work in these plugins get applied to almost every project I touch, so I figued I should consolidate the work into one place.

I've also updated gradle to 8.3, and added toolchain resolution to get rid of the gradle build warning about deprecated apis.