### PR TITLE
Kotlin support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,8 +39,9 @@ jib = { module = "com.google.cloud.tools:jib-gradle-plugin", version.ref = "jib"
 junit = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "1.9.3" }
 klaxon = { module = "com.beust:klaxon", version.ref = "klaxon" }
-kotlin-logging = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlin-logging" }
 kotlin-guice = { module = "dev.misfitlabs.kotlinguice4:kotlin-guice", version.ref = "kotlin-guice" }
+kotlin-jvm-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin"}
+kotlin-logging = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlin-logging" }
 lambda-core = { module = "com.amazonaws:aws-lambda-java-core", version = { strictly = "1.2.1" } }
 lambda-events = { module = "com.amazonaws:aws-lambda-java-events", version = { strictly = "3.9.0" } }
 lambda-runtime = { module = "com.amazonaws:aws-lambda-java-runtime-interface-client", version = { strictly = "2.1.1" } }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ jib = { module = "com.google.cloud.tools:jib-gradle-plugin", version.ref = "jib"
 junit = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "1.9.3" }
 klaxon = { module = "com.beust:klaxon", version.ref = "klaxon" }
+kotlin-allopen = { module = "org.jetbrains.kotlin:kotlin-allopen", version.ref = "kotlin"}
 kotlin-guice = { module = "dev.misfitlabs.kotlinguice4:kotlin-guice", version.ref = "kotlin-guice" }
 kotlin-jvm-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin"}
 kotlin-logging = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlin-logging" }

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     api(libs.spring.boot.gradle)
     api(libs.spring.boot.jib.extension)
     api(libs.spring.dependency.management)
+    api(libs.kotlin.jvm.plugin)
     compileOnly(libs.jetbrains.annotations)
 
     testImplementation(gradleTestKit())

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     api(libs.spring.boot.jib.extension)
     api(libs.spring.dependency.management)
     api(libs.kotlin.jvm.plugin)
+    api(libs.kotlin.allopen)
     compileOnly(libs.jetbrains.annotations)
 
     testImplementation(gradleTestKit())

--- a/plugins/src/main/kotlin/info/offthecob/gradle/BasePlugin.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/BasePlugin.kt
@@ -15,6 +15,9 @@ class BasePlugin : Plugin<Project> {
             apply(JavaPlugin::class.java)
             apply(JavaCustomization::class.java)
             apply(GroovyPlugin::class.java)
+            apply("kotlin")
+            apply(KotlinCustomization::class.java)
+
             apply(NullAwayPlugin::class.java)
             apply(NullAwayCustomization::class.java)
             apply(DependencyLocking::class.java)

--- a/plugins/src/main/kotlin/info/offthecob/gradle/DefaultVersions.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/DefaultVersions.kt
@@ -1,0 +1,6 @@
+package info.offthecob.gradle
+
+const val SPRING_BOOT_DEFAULT_VERSION = "3.1.2"
+const val DGS_DEFAULT_VERSION = "7.3.6"
+const val KOTLIN_DEFAULT_VERSION = "1.9.0"
+const val JVM_DEFAULT_VERSION = 17

--- a/plugins/src/main/kotlin/info/offthecob/gradle/DependencyManagementCustomization.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/DependencyManagementCustomization.kt
@@ -14,22 +14,23 @@ class DependencyManagementCustomization : Plugin<Project> {
             project.logger.log(LogLevel.WARN, "plugin under test, bypassing DependencyManagementCustomization")
             return
         }
-        val dependencyManagement = project.extensions.getByType(DependencyManagementExtension::class.java)
-        val catalog = versionCatalog(project)
-        dependencyManagement.imports {
-            listOf(
-                Pair(
-                    "org.springframework.boot:spring-boot-dependencies",
-                    if (catalog.findVersion(SPRING_BOOT).isPresent) catalog.findVersion(SPRING_BOOT).get() else "3.1.2",
-                ),
-                Pair(
-                    "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies",
-                    if (catalog.findVersion(DGS).isPresent) catalog.findVersion(DGS).get() else "7.3.6",
-                ),
-            )
-                .forEach { (path, version) ->
-                    mavenBom("$path:$version")
-                }
-        }
+        project
+            .extensions
+            .getByType(DependencyManagementExtension::class.java)
+            .imports {
+                listOf(
+                    Pair(
+                        "org.springframework.boot:spring-boot-dependencies",
+                        getVersion(project, SPRING_BOOT, SPRING_BOOT_DEFAULT_VERSION),
+                    ),
+                    Pair(
+                        "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies",
+                        getVersion(project, DGS, DGS_DEFAULT_VERSION),
+                    ),
+                )
+                    .forEach { (path, version) ->
+                        mavenBom("$path:$version")
+                    }
+            }
     }
 }

--- a/plugins/src/main/kotlin/info/offthecob/gradle/HelperFunctions.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/HelperFunctions.kt
@@ -19,3 +19,18 @@ fun versionCatalog(project: Project): VersionCatalog {
         throw GradleException("This plugin expects a Version Catalog named 'libs', see https://docs.gradle.org/current/userguide/platforms.html")
     }
 }
+
+fun getVersion(project: Project, name: String, default: String): String {
+    val catalog: VersionCatalog? = try {
+        project.rootProject.extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
+    } catch (_: UnknownDomainObjectException) {
+        null
+    }
+
+    return if (catalog != null && catalog.findVersion(name).isPresent) {
+        catalog.findVersion(name).get().toString()
+    } else {
+        project.logger.info("Plugin looked in Version Catalog 'libs' for version $name, and did not find anything, using default value $default.")
+        default
+    }
+}

--- a/plugins/src/main/kotlin/info/offthecob/gradle/HelperFunctions.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/HelperFunctions.kt
@@ -28,7 +28,9 @@ fun getVersion(project: Project, name: String, default: String): String {
     }
 
     return if (catalog != null && catalog.findVersion(name).isPresent) {
-        catalog.findVersion(name).get().toString()
+        val version = catalog.findVersion(name).get().toString()
+        project.logger.info("Using catalog version $version for $name")
+        version
     } else {
         project.logger.info("Plugin looked in Version Catalog 'libs' for version $name, and did not find anything, using default value $default.")
         default

--- a/plugins/src/main/kotlin/info/offthecob/gradle/HelperFunctions.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/HelperFunctions.kt
@@ -12,14 +12,6 @@ fun pluginUnderTest(project: Project): Boolean {
     return ext.properties.containsKey(PROJECT_BUILDER_TEST)
 }
 
-fun versionCatalog(project: Project): VersionCatalog {
-    try {
-        return project.rootProject.extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
-    } catch (_: UnknownDomainObjectException) {
-        throw GradleException("This plugin expects a Version Catalog named 'libs', see https://docs.gradle.org/current/userguide/platforms.html")
-    }
-}
-
 fun getVersion(project: Project, name: String, default: String): String {
     val catalog: VersionCatalog? = try {
         project.rootProject.extensions.getByType(VersionCatalogsExtension::class.java).named("libs")

--- a/plugins/src/main/kotlin/info/offthecob/gradle/HelperFunctions.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/HelperFunctions.kt
@@ -1,6 +1,5 @@
 package info.offthecob.gradle
 
-import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.VersionCatalog

--- a/plugins/src/main/kotlin/info/offthecob/gradle/JavaCustomization.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/JavaCustomization.kt
@@ -7,7 +7,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JvmVendorSpec
 
-val JVM_VERSION = JavaLanguageVersion.of(17)
+val JVM_VERSION = JavaLanguageVersion.of(JVM_DEFAULT_VERSION)
 val JVM_VENDOR = JvmVendorSpec.ADOPTIUM
 
 class JavaCustomization : Plugin<Project> {

--- a/plugins/src/main/kotlin/info/offthecob/gradle/KotlinCustomization.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/KotlinCustomization.kt
@@ -1,0 +1,27 @@
+package info.offthecob.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+class KotlinCustomization : Plugin<Project> {
+    override fun apply(project: Project) {
+        configureKotlinPluginExtension(project)
+        configureKotlinCompileTasks(project)
+    }
+
+    private fun configureKotlinPluginExtension(project: Project) {
+        val kotlinExtension = project.extensions.findByType(KotlinProjectExtension::class.java)!!
+        kotlinExtension.coreLibrariesVersion = getVersion(project, "kotlin", KOTLIN_DEFAULT_VERSION)
+    }
+
+    private fun configureKotlinCompileTasks(project: Project) {
+        project.tasks.withType(KotlinCompile::class.java) {
+            kotlinOptions {
+                freeCompilerArgs += "-Xjsr305=strict"
+                jvmTarget = "$JVM_DEFAULT_VERSION"
+            }
+        }
+    }
+}

--- a/plugins/src/main/kotlin/info/offthecob/gradle/SpringService.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/SpringService.kt
@@ -13,6 +13,7 @@ class SpringService : Plugin<Project> {
             apply(DependencyManagementCustomization::class.java)
             apply(SpringBootPlugin::class.java)
             apply(JibSpringCustomization::class.java)
+            apply("kotlin-spring")
         }
     }
 }

--- a/plugins/src/test/groovy/info/offthecob/gradle/DependencyLockingIntegrationTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/DependencyLockingIntegrationTest.groovy
@@ -11,6 +11,7 @@ class DependencyLockingIntegrationTest extends IntegrationSpec {
                 "clean",
                 "spotlessApply",
                 "check",
+                "--write-locks",
                 "-Pproject_directory=${projectDirectory}" as String
         ] as List<String>
 
@@ -19,9 +20,9 @@ class DependencyLockingIntegrationTest extends IntegrationSpec {
                 .withPluginClasspath()
                 .withProjectDir(projectDirectory)
                 .withArguments(gradleArguments)
-                .buildAndFail()
+                .build()
 
         then:
-        result.task(":compileKotlin").getOutcome() == TaskOutcome.FAILED
+        result.task(":compileKotlin").getOutcome() == TaskOutcome.SUCCESS
     }
 }

--- a/plugins/src/test/groovy/info/offthecob/gradle/IntegrationTestUtils.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/IntegrationTestUtils.groovy
@@ -53,7 +53,6 @@ class IntegrationTestUtils {
         buildGradle << """
         plugins {
             id("info.offthecob.Base")
-            kotlin("jvm") version "1.9.0"
         }
         dependencies {
             implementation(libs.google.guice)
@@ -105,6 +104,19 @@ class IntegrationTestUtils {
                 then:
                 observed == Main.FORMATTED_STRING.formatted(input)
             }
+            
+            def "kotlin expected outputs"() {
+                given:
+                def input = "input"
+                def input2 = "input2"
+                def input3 = "input3"
+                
+                when:
+                def observed = KotlinFunctionalKt.functionalFun(input, input2, input3)
+                
+                then:
+                observed == "\$input \$input2 \$input3 functional"
+            }
         }
         """.stripIndent()
         mainTestFile << mainTest
@@ -119,7 +131,7 @@ class IntegrationTestUtils {
         def function = """
         package info.offthecob.testing
         fun functionalFun(input: String, input2: String,
-                          input3: String): String { return "${'$'}input functional" }
+                          input3: String): String { return "${'$'}input ${'$'}input2 ${'$'}input3 functional" }
         """.stripIndent()
         kotlinFile << function
     }

--- a/plugins/src/test/groovy/info/offthecob/gradle/KotlinCustomizationTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/KotlinCustomizationTest.groovy
@@ -1,0 +1,72 @@
+package info.offthecob.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+
+import static info.offthecob.gradle.DefaultVersionsKt.KOTLIN_DEFAULT_VERSION
+
+
+class KotlinCustomizationTest extends IntegrationSpec {
+
+    def "kotlin version can be overridden"() {
+        given:
+        def settingsGradle = new File(projectDirectory, "settings.gradle.kts")
+        settingsGradle.delete()
+        def settings = """
+        plugins {
+            id("org.gradle.toolchains.foojay-resolver") version "0.6.0"
+        }
+        rootProject.name = "test-project"
+        toolchainManagement {
+            jvm {
+                javaRepositories {
+                    repository("foojay") {
+                        resolverClass.set(org.gradle.toolchains.foojay.FoojayToolchainResolver::class.java)
+                    }
+                }
+            }
+        }
+        dependencyResolutionManagement {
+            repositories {
+                mavenCentral()
+                gradlePluginPortal()
+            }
+            versionCatalogs {
+                create("libs"){
+                    $versionString
+                    library("google-guice", "com.google.inject:guice:5.1.0")
+                    library("spock-core", "org.spockframework:spock-core:2.2-M1-groovy-3.0")
+                    library("junit", "org.junit.jupiter:junit-jupiter-api:5.9.1")
+                    library("junit-platform-launcher", "org.junit.platform:junit-platform-launcher:1.9.3")
+                }
+            }
+        }
+        """.stripIndent()
+        settingsGradle << settings
+        def gradleArguments = [
+                "compileKotlin",
+                "dependencies",
+                "-x",
+                "test",
+                "-Pproject_directory=${projectDirectory}" as String,
+                "--write-locks"
+        ] as List<String>
+
+        when:
+        def result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(projectDirectory)
+                .withArguments(gradleArguments)
+                .build()
+
+        then:
+        result.output.contains("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
+        result.task(":compileKotlin").outcome == TaskOutcome.SUCCESS
+
+        where:
+        kotlinVersion          | versionString
+        "1.8.21"               | """version("kotlin", "$kotlinVersion")"""
+        KOTLIN_DEFAULT_VERSION | ""
+    }
+
+}


### PR DESCRIPTION
* Reworks how the catalog interactions work. Specifically, choose good defaults when overrides aren't present. 
* Adds the kotlin build plugin, so that projects get kotlin support by default.
* Adds kotlin-spring annotation processor