### PR TITLE
Setup project for publishing to gradle plugin portal

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,15 +12,17 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Publish package
+      - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: publish
+      - name: Publish Packages
+        run: ./gradlew common:publish catalog:publish plugins:publishPlugins
         env:
           USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REVISION: ${{ github.event.release.tag_name }}
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ A list of best practices around dependency locking, linting, and other build bes
 This subproject also allows me to do all the things I do in every project in one place, cleaning up
 the downstream consumer's gradle files.
 
+If a version catalog exists with the following version definitions, the plugins below will use those version
+instead of the defaults.
+
+* `kotlin` manages the version of the kotlin toolchain.
+* `dgs` the version of Netflix DGS BOM to expose to the dependency management plugin.
+* `spring-boot` the version of Spring Boot BOM to expose to the dependency management plugin.
+
 ## Base
 This plugin contains what I think are best practices for all jvm projects.
 
@@ -44,8 +51,8 @@ plugins {
 
 ## Spring Service
 This uses everything in Service, but also adds the Spring special sauce.
-Specifically, it adds the spring boot and dependency management plugins into scope, and customizes them
-with best practices. It also applies the jib extension for Spring.
+Specifically, it adds the `spring-boot`, `dependency-management` and `kotlin-spring` plugins into scope,
+and customizes them with best practices. It also applies the jib extension for Spring.
 
 ```gradle
 plugins {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,3 +76,4 @@ kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "ko
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 nullaway = { id = "net.ltgt.nullaway", version.ref = "nullaway-plugin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+gradle-publish-plugin = { id = "com.gradle.plugin-publish", version = "1.1.0"}

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     groovy
     `kotlin-dsl`
     alias(libs.plugins.spotless)
+    alias(libs.plugins.gradle.publish.plugin)
 }
 
 repositories {
@@ -19,23 +20,49 @@ java {
     }
 }
 
+group = "info.offthecob"
+version = System.getenv("REVISION") ?: "v9999999999"
+
 gradlePlugin {
+    website.set("https://github.com/whodevil/jvm-platform")
+    vcsUrl.set("https://github.com/whodevil/jvm-platform.git")
     plugins {
         create("base") {
             id = "info.offthecob.Base"
             implementationClass = "info.offthecob.gradle.BasePlugin"
+            tags.set(listOf("kotlin", "java", "groovy", "conventions"))
+            displayName = "Offthecob JVM Base"
+            description = "This plugin contains a bunch of best practices around how to build projects for the JVM. " +
+                    "This includes dependency locking by default, kotlin support, groovy support (for testing), wiring up the " +
+                    "junit platform, null away, and linting."
         }
         create("service") {
             id = "info.offthecob.Service"
             implementationClass = "info.offthecob.gradle.ServicePlugin"
+            tags.set(listOf("kotlin", "java", "groovy", "conventions", "jib", "containers"))
+            displayName = "Offthecob JVM Service"
+            description =
+                "This plugin contains all the work from `info.offthecob.Base` but includes `jib` for building " +
+                        "containers."
         }
         create("library") {
             id = "info.offthecob.Library"
             implementationClass = "info.offthecob.gradle.LibraryPlugin"
+            tags.set(listOf("kotlin", "java", "groovy", "conventions", "library"))
+            displayName = "Offthecob JVM Library"
+            description =
+                "This plugin contains all the work from `info.offthecob.Base` but includes `java-library` for " +
+                        "building jvm libraries."
         }
         create("springService") {
             id = "info.offthecob.SpringService"
             implementationClass = "info.offthecob.gradle.SpringService"
+            tags.set(listOf("kotlin", "java", "groovy", "conventions", "jib", "containers", "spring"))
+            displayName = "Offthecob JVM Spring Service"
+            description =
+                "This plugin contains all the work from `info.offthecob.Service` but includes customization of " +
+                        "the dependency management plugin used by spring, and applies the `kotlin-spring` and `spring-boot` " +
+                        "plugins."
         }
     }
 }
@@ -62,9 +89,21 @@ tasks {
     named("testClasses") {
         dependsOn("pluginUnderTestMetadata")
     }
-
+    named("publishPlugins") {
+        dependsOn("handlePluginPublishSecrets")
+    }
     withType<Test>().configureEach {
         useJUnitPlatform()
+    }
+    register("handlePluginPublishSecrets") {
+        doLast {
+            val key = System.getenv("GRADLE_PUBLISH_KEY")
+                ?: throw GradleException("Attempting to publish plugin without GRADLE_PUBLISH_KEY set.")
+            val secret = System.getenv("GRADLE_PUBLISH_SECRET")
+                ?: throw GradleException("Attempting to publish plugin without GRADLE_PUBLISH_SECRET set.")
+            System.setProperty("gradle.publish.key", key)
+            System.setProperty("gradle.publish.secret", secret)
+        }
     }
 }
 


### PR DESCRIPTION
* Update the README with some useful documentation, annotated the plugins with useful information for when they are published.
* Stop publishing plugins to github packages, publish them to gradle plugin portal instead.
* Add gradle plugin publishing plugin to version catalog.