### PR TITLE
Only publish common to github packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Publish Packages
-        run: ./gradlew common:publishCommonPublicationToOSSRHRepository catalog:publishCatalogPublicationToOSSRHRepository plugins:publishPlugins
+        run: ./gradlew common:publishCommonPublicationToGitHubPackagesRepository catalog:publishCatalogPublicationToOSSRHRepository plugins:publishPlugins
         env:
           USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For now, common doesn't have much value, so don't publish it to maven central.