### PR TITLE
Add kotlin allopen to base plugin

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,0 @@
-before_install:
-   - sdk install java 17.0.8-tem
-   - sdk use java 17.0.8-tem
-

--- a/plugins/src/main/kotlin/info/offthecob/gradle/BasePlugin.kt
+++ b/plugins/src/main/kotlin/info/offthecob/gradle/BasePlugin.kt
@@ -16,6 +16,7 @@ class BasePlugin : Plugin<Project> {
             apply(JavaCustomization::class.java)
             apply(GroovyPlugin::class.java)
             apply("kotlin")
+            apply("kotlin-allopen")
             apply(KotlinCustomization::class.java)
 
             apply(NullAwayPlugin::class.java)

--- a/plugins/src/test/groovy/info/offthecob/gradle/KotlinAllOpenTest.groovy
+++ b/plugins/src/test/groovy/info/offthecob/gradle/KotlinAllOpenTest.groovy
@@ -1,0 +1,17 @@
+package info.offthecob.gradle
+
+import org.jetbrains.kotlin.allopen.gradle.AllOpenExtension
+
+class KotlinAllOpenTest extends UnitSpec {
+    def setupSpec() {
+        setupProject("info.offthecob.Base")
+    }
+
+    def "contains allopen extension"() {
+        given:
+        def extension = project.extensions.getByType(AllOpenExtension.class)
+
+        expect:
+        extension != null
+    }
+}


### PR DESCRIPTION
Allopen is the way to enable mocking in tests for kotlin. By default every class is final, and this compile plugin enables adding a plugin to remove final, or to make the class open.