### PR TITLE
Add BOM and Common artifacts to maven central

### DIFF
--- a/.github/workflows/onMain.yaml
+++ b/.github/workflows/onMain.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Publish Packages
-        run: ./gradlew common:publishCommonPublicationToGitHubPackagesRepository catalog:publishCatalogPublicationToGitHubPackagesRepository
+        run: ./gradlew common:publishCommonPublicationToGitHubPackagesRepository catalog:publishCatalogPublicationToGitHubPackagesRepository bom:publishBOMPublicationToGitHubPackagesRepository
         env:
           USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Publish Packages
-        run: ./gradlew catalog:publishCatalogPublicationToOSSRHRepository plugins:publishPlugins
+        run: ./gradlew common:publishCommonPublicationToOSSRHRepository catalog:publishCatalogPublicationToOSSRHRepository bom:publishBOMPublicationToOSSRHRepository plugins:publishPlugins
         env:
           USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bom/bom.gradle.kts
+++ b/bom/bom.gradle.kts
@@ -1,0 +1,49 @@
+plugins {
+    `java-platform`
+    signing
+}
+
+dependencies {
+    constraints {
+        api(project(":common"))
+        api(project(":catalog"))
+    }
+}
+
+configure<PublishingExtension> {
+    publications {
+        register<MavenPublication>("BOM") {
+            from(components["javaPlatform"])
+            pom {
+                name.set("bom")
+                description.set("Bill of Materials (BOM) for info.offthecob.platform")
+                url.set("https://github.com/whodevil/jvm-platform")
+                licenses {
+                    license {
+                        name.set("The MIT License")
+                        url.set("https://opensource.org/license/mit/")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("whodevil")
+                        name.set("Devon Gleeson")
+                        email.set("whodevil@offthecob.info")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:git://github.com/whodevil/jvm-platform.git")
+                    developerConnection.set("scm:git:ssh://github.com:whodevil/jvm-platform.git")
+                    url.set("https://github.com/whodevil/jvm-platform/tree/master")
+                }
+            }
+        }
+    }
+}
+
+signing {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications["BOM"])
+}


### PR DESCRIPTION
The BOM will enable gradle platform import. Common is getting published to maven central now so that the OpenForTesting annotation can be wired up to the kotlin allopen compiler plugin.